### PR TITLE
add canvas dimension to exif

### DIFF
--- a/example.json
+++ b/example.json
@@ -5,7 +5,9 @@
     "imageDescription": "only 3 pixels",
     "userComment": "made as an example for pxon",
     "copyright": "jenn schiffer 2015",
-    "dateTime": "2015-10-23T18:09:51.761Z"
+    "dateTime": "2015-10-23T18:09:51.761Z",
+    "imageWidth": 100,
+    "imageLength": 100
   },
   "pxif": {
     "pixels": [
@@ -14,7 +16,7 @@
         "y": 15,
         "color": "rgba(0, 0, 0, 1)",
         "size": 15
-      },      
+      },
       {
         "x": 45,
         "y": 45,

--- a/pxon-schema.md
+++ b/pxon-schema.md
@@ -1,11 +1,11 @@
 # PXON schema
 
 ## structure
-    
-PXON is <abbr title="JavaScript Object Notation">[JSON](http://json.org/)</abbr> representing pixel art. 
+
+PXON is <abbr title="JavaScript Object Notation">[JSON](http://json.org/)</abbr> representing pixel art.
 
 There are two objects in PXON, <abbr title="Exchangeable image file format">[Exif](http://www.w3.org/2003/12/exif/)</abbr> and <abbr title="pixel image file format">`pxif`</abbr>. `exif` has any properties defined by the Exif <abbr title="Resource Description Framework">[RDF](http://www.w3.org/RDF/)</abbr> schema. For the sake of creating pixel art, many of these properties are not necessary or even applicable. They have been narrowed down to:
-    
+
 
 * `software`: (string) the software used to create/export the pxon
 * `artist`: (string) the identity of the artist of the work the pxon represents
@@ -13,8 +13,10 @@ There are two objects in PXON, <abbr title="Exchangeable image file format">[Exi
 * `userComment`: (string) a comment from the user generating the pxon
 * `copyright`: (string) the copyright of the image
 * `dateTime`: (string) the date/Time the pxon was initially generated
+* `imageWidth`: (integer) the display pixel width of the image canvas
+* `imageLength`: (integer) the display pixel height of the image canvas
 
-    
+
 `pxif` is the pixel art spin of `exif`, in essense it is unique to pixel art and breaks down the image beyond it's typical metadata and focuses on the individual strokes and drawings of the pixels within the image. The first property, `pixels` is an array of "pixel" objects representing the pixels drawn in the image. Because it is a new idea in this format, the list of properties is fluid and ever changing at the moment. They are:
 
 
@@ -25,7 +27,7 @@ There are two objects in PXON, <abbr title="Exchangeable image file format">[Exi
 
 
 A `dataURL` property has a string value of the dataURL of the canvas the pixel art had when pxon is exported. This may be helpful for drawing the inital image on pxon import but it may be best to just redraw each pixel in the `pixels` array. Until the apps using pxon are refined, it's best to keep this property here I believe.
-    
+
 ```json
 {
   "exif": {
@@ -34,7 +36,9 @@ A `dataURL` property has a string value of the dataURL of the canvas the pixel a
     "imageDescription"  : "",
     "userComment"       : "",
     "copyright"         : "",
-    "dateTime"          : ""
+    "dateTime"          : "",
+    "imageWidth"        : 0,
+    "imageLength"       : 0
   },
   "pxif": {
     "pixels"  : [


### PR DESCRIPTION
closes #3 

adds the `imageWidth` and `imageLength` exif properties to the schema so we can know how many display pixels the size of the image canvas should be. view #3 for more context.
